### PR TITLE
Add setMissingQueuesFatal(false) for remove queue case

### DIFF
--- a/sdk/trade360-java-sdk/src/main/java/com/lsports/trade360_java_sdk/feed/rabbitmq/configurations/DynamicRabbitMQDefinitionRegistrar.java
+++ b/sdk/trade360-java-sdk/src/main/java/com/lsports/trade360_java_sdk/feed/rabbitmq/configurations/DynamicRabbitMQDefinitionRegistrar.java
@@ -66,6 +66,7 @@ public class DynamicRabbitMQDefinitionRegistrar implements BeanDefinitionRegistr
                                 factory.setMaxConcurrentConsumers(rabbitConnectionConfiguration.max_concurrent_consumers);
                                 factory.setPrefetchCount(rabbitConnectionConfiguration.prefetch_count);
                                 factory.setRecoveryInterval(rabbitConnectionConfiguration.network_recovery_interval);
+                                factory.setMissingQueuesFatal(false);
                                 return factory;
                             });
 


### PR DESCRIPTION
﻿### Jira Ticket: [MON-1605](https://lsports-data.atlassian.net/browse/MON-1605)

## Changes:
Set `missingQueuesFatal` to `false` for Rabbit connection in case of the remove queue .It changes the excepetion rank from fatal to normal. 

[MON-1605]: https://lsports-data.atlassian.net/browse/MON-1605?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ