### PR TITLE
Disabled buffering for large size responses

### DIFF
--- a/sdk/trade360-java-sdk/src/main/java/com/lsports/trade360_java_sdk/common/springframework/SpringBootApiRestClient.java
+++ b/sdk/trade360-java-sdk/src/main/java/com/lsports/trade360_java_sdk/common/springframework/SpringBootApiRestClient.java
@@ -44,6 +44,7 @@ public class SpringBootApiRestClient implements ApiRestClient {
         this.client = builder
             .baseUrl(baseUrl.toString())
             .codecs(config -> {
+                config.defaultCodecs().maxInMemorySize(-1);
                 config.defaultCodecs().jackson2JsonEncoder(new Jackson2JsonEncoder(serializer.getObjectMapper()));
                 config.defaultCodecs().jackson2JsonDecoder(new Jackson2JsonDecoder(serializer.getObjectMapper(), new MediaType[] {MediaType.APPLICATION_JSON, MediaType.APPLICATION_OCTET_STREAM, MediaType.APPLICATION_PROBLEM_JSON}));
             })


### PR DESCRIPTION
﻿### Jira Ticket: [jira code](url)

### Requirements:

Write in one or two phrases what requirements have been determined for the issue:

- [ ] Unit tests added. 
- [x] Has been tested locally.
- [x] Has been tested on DEV.

## Changes:

Describe what changes have been included into pull request:

Some Snapshot API responses when no filters are appended are HUUGE, which by default may cause out of buffer errors. For this sake the buffer has been disabled.

## Additional information:

If you would like to add more information about pull request, issue etc. feel free to insert it here:

#### Remember to update documentation after merge.