### PR TITLE
Update Dockerfile.publish to enhance Maven deploy command with verbos…

### DIFF
--- a/sdk/trade360-java-sdk/Dockerfile.publish
+++ b/sdk/trade360-java-sdk/Dockerfile.publish
@@ -28,11 +28,11 @@ COPY settings.xml /root/.m2/settings.xml
 # Copy the project files
 COPY . .
 
-# Run Maven deploy with debug flags and print environment for debugging
-RUN env && \
-    mvn clean deploy -P release \
-    -Dmaven.test.skip=true -e \
+# Run Maven deploy with verbose logs and explicit GPG executable
+RUN mvn clean deploy -P release \
+    -Dmaven.test.skip=true -e -X \
     -f sdk/trade360-java-sdk/pom.xml \
     -DMAVEN_USERNAME=${MAVEN_USERNAME} \
     -DMAVEN_PASSWORD=${MAVEN_PASSWORD} \
-    -DGPG_PASSPHRASE=${GPG_PASSPHRASE}
+    -DGPG_PASSPHRASE=${GPG_PASSPHRASE} \
+    -Dgpg.executable=gpg


### PR DESCRIPTION
# User description
…e logging and specify GPG executable

﻿### Jira Ticket: [jira code](url)

### Requirements:

Write in one or two phrases what requirements have been determined for the issue:

- [ ] Unit tests added. 
- [ ] Has been tested locally.
- [ ] Has been tested on DEV.

## Changes:

Describe what changes have been included into pull request:

## Additional information:

If you would like to add more information about pull request, issue etc. feel free to insert it here:

#### Remember to update documentation after merge.

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Update the trade360 Java SDK release build to use verbose Maven logs and explicit GPG binary for deployment, clarifying output and ensuring the signing step works on non-default environments. Adjust the Maven deployment command in the Docker publishing pipeline to retain the current credentials and plugins while adding the <code>-X</code> flag and <code>-Dgpg.executable=gpg</code> property.


<details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>shir.b@lsports.eu</td><td>Update Dockerfile.publ...</td><td>May 07, 2026</td></tr>
<tr><td>yehorazl</td><td>Update Dockerfile.publish</td><td>March 30, 2025</td></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/lsportsltd/trade360-java-sdk/126?tool=ast>(Baz)</a>.