### PR TITLE
Add outright and participant model updates with version bump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Release Version 2.9.2] - 2026-05-07
+
+### Added
+
+- Added `startDate` to outright league fixture models:
+  - `OutrightLeagueFixture`
+  - `OutrightLeagueFixtureSnapshot`
+
+- Added new livescore status description values `46-59`.
+
+- Added participant uniform color support with object-based shirt color fields (`shirtColor`, `goalKeeperShirtColor`) using `primary`, `number`, and `outline`.
+
+### Changed
+
+- Bumped project/module versions from `2.9.1` to `2.9.2` for a new publishable release.
+
 ## [Release Version 2.9.1] - 2026-02-01
 
 ### Fixed

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>eu.lsports</groupId>
 	<artifactId>trade360-java</artifactId>
-	<version>2.9.1</version>
+	<version>2.9.2</version>
 	<packaging>pom</packaging>
 
 	<modules>

--- a/samples/trade360-samples/pom.xml
+++ b/samples/trade360-samples/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>eu.lsports</groupId>
     <artifactId>trade360-samples</artifactId>
-    <version>2.9.1</version>
+    <version>2.9.2</version>
     <name>trade360-samples</name>
     <description>LSports trade360-samples java sdk</description>
     <properties>
@@ -20,7 +20,7 @@
         <dependency>
             <groupId>eu.lsports</groupId>
             <artifactId>trade360-java-sdk</artifactId>
-            <version>2.9.1</version>
+            <version>2.9.2</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/sdk/trade360-java-sdk/Dockerfile.publish
+++ b/sdk/trade360-java-sdk/Dockerfile.publish
@@ -28,11 +28,11 @@ COPY settings.xml /root/.m2/settings.xml
 # Copy the project files
 COPY . .
 
-# Run Maven deploy with debug flags and print environment for debugging
-RUN env && \
-    mvn clean deploy -P release \
-    -Dmaven.test.skip=true -e \
+# Run Maven deploy with verbose logs and explicit GPG executable
+RUN mvn clean deploy -P release \
+    -Dmaven.test.skip=true -e -X \
     -f sdk/trade360-java-sdk/pom.xml \
     -DMAVEN_USERNAME=${MAVEN_USERNAME} \
     -DMAVEN_PASSWORD=${MAVEN_PASSWORD} \
-    -DGPG_PASSPHRASE=${GPG_PASSPHRASE}
+    -DGPG_PASSPHRASE=${GPG_PASSPHRASE} \
+    -Dgpg.executable=gpg

--- a/sdk/trade360-java-sdk/Dockerfile.publish
+++ b/sdk/trade360-java-sdk/Dockerfile.publish
@@ -28,11 +28,11 @@ COPY settings.xml /root/.m2/settings.xml
 # Copy the project files
 COPY . .
 
-# Run Maven deploy with verbose logs and explicit GPG executable
-RUN mvn clean deploy -P release \
-    -Dmaven.test.skip=true -e -X \
+# Run Maven deploy with debug flags and print environment for debugging
+RUN env && \
+    mvn clean deploy -P release \
+    -Dmaven.test.skip=true -e \
     -f sdk/trade360-java-sdk/pom.xml \
     -DMAVEN_USERNAME=${MAVEN_USERNAME} \
     -DMAVEN_PASSWORD=${MAVEN_PASSWORD} \
-    -DGPG_PASSPHRASE=${GPG_PASSPHRASE} \
-    -Dgpg.executable=gpg
+    -DGPG_PASSPHRASE=${GPG_PASSPHRASE}

--- a/sdk/trade360-java-sdk/pom.xml
+++ b/sdk/trade360-java-sdk/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>eu.lsports</groupId>
     <artifactId>trade360-java-sdk</artifactId>
-    <version>2.9.1</version>
+    <version>2.9.2</version>
     <name>trade360-java-sdk</name>
     <description>LSports trade360 java sdk</description>
     <parent>


### PR DESCRIPTION
# User description
## Summary
- add outright league fixture `startDate` support and participant uniform color fields across SDK entities/tests
- extend livescore status descriptions and keep backward-compatible handling in related models
- bump Java project versions to `2.9.2` and update changelog for the new publishable release

## Test plan
- [x] Run focused entity tests after conflict resolution (`ParticipantTest`, `OutrightLeagueFixtureTest`, `OutrightLeagueFixtureSnapshotTest`)
- [ ] Run full CI pipeline (build, tests, publish stages)
- [ ] Verify Maven Central publish uses `2.9.2`

Made with [Cursor](https://cursor.com)

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Document the new <code>startDate</code> and participant uniform color fields alongside expanded livescore status descriptions for the SDK’s outright league fixtures and participant entities. Update Maven coordinates and release notes to reflect the <code>2.9.2</code> publishable version.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/lsportsltd/trade360-java-sdk/127?tool=ast&topic=Release+Version+Bump>Release Version Bump</a>
        </td><td>Update Maven modules to version <code>2.9.2</code> for the root, samples, and SDK artifacts to align with the new release.<details><summary>Modified files (3)</summary><ul><li>pom.xml</li>
<li>samples/trade360-samples/pom.xml</li>
<li>sdk/trade360-java-sdk/pom.xml</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>shir.b@lsports.eu</td><td>Update CHANGELOG for r...</td><td>May 07, 2026</td></tr>
<tr><td>PavelTemno</td><td>fix versioning</td><td>January 27, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/lsportsltd/trade360-java-sdk/127?tool=ast&topic=Fixture+%26+Participant+Data>Fixture & Participant Data</a>
        </td><td>Document <code>OutrightLeagueFixture</code> and participant coverage by adding <code>startDate</code>, uniform color fields, and the extended <code>46-59</code> livescore status descriptions to the changelog.<details><summary>Modified files (1)</summary><ul><li>CHANGELOG.md</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>shir.b@lsports.eu</td><td>Update CHANGELOG for r...</td><td>May 07, 2026</td></tr>
<tr><td>PavelTemno</td><td>fix versioning</td><td>January 27, 2026</td></tr></table></details></td></tr></table>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/lsportsltd/trade360-java-sdk/127?tool=ast>(Baz)</a>.