### PR TITLE
TRGN-3848: Add MarketId to TransportMessageHeaders (v2.10.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Release Version 2.10.1] - 2026-06-14
+
+### Added
+
+- **`TransportMessageHeaders`**: optional `MarketId` customer message header (TRGN-3848).
+
+### Changed
+
+- Bumped project/module versions from `2.10.0` to `2.10.1` for a new publishable release.
+
 ## [Release Version 2.10.0] - 2026-05-31
 
 ### Added

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>eu.lsports</groupId>
 	<artifactId>trade360-java</artifactId>
-	<version>2.10.0</version>
+	<version>2.10.1</version>
 	<packaging>pom</packaging>
 
 	<modules>

--- a/samples/trade360-samples/pom.xml
+++ b/samples/trade360-samples/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>eu.lsports</groupId>
     <artifactId>trade360-samples</artifactId>
-    <version>2.10.0</version>
+    <version>2.10.1</version>
     <name>trade360-samples</name>
     <description>LSports trade360-samples java sdk</description>
     <properties>
@@ -20,7 +20,7 @@
         <dependency>
             <groupId>eu.lsports</groupId>
             <artifactId>trade360-java-sdk</artifactId>
-            <version>2.10.0</version>
+            <version>2.10.1</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/sdk/trade360-java-sdk/pom.xml
+++ b/sdk/trade360-java-sdk/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>eu.lsports</groupId>
     <artifactId>trade360-java-sdk</artifactId>
-    <version>2.10.0</version>
+    <version>2.10.1</version>
     <name>trade360-java-sdk</name>
     <description>LSports trade360 java sdk</description>
     <parent>

--- a/sdk/trade360-java-sdk/src/main/java/eu/lsports/trade360_java_sdk/common/models/TransportMessageHeaders.java
+++ b/sdk/trade360-java-sdk/src/main/java/eu/lsports/trade360_java_sdk/common/models/TransportMessageHeaders.java
@@ -14,12 +14,14 @@ public class TransportMessageHeaders {
     private static final String TIMESTAMP_IN_MS_KEY = "timestamp_in_ms";
     private static final String MESSAGE_SEQUENCE_KEY = "MessageSequence";
     private static final String FIXTURE_ID_KEY = "FixtureId";
+    private static final String MARKET_ID_KEY = "MarketId";
     private static final String SPORT_ID_KEY = "SportId";
 
     private final String messageType;
     private final String messageSequence;
     private final String messageGuid;
     private final String fixtureId;
+    private final String marketId;
     private final String sportId;
     private final String timestampInMs;
 
@@ -32,15 +34,17 @@ public class TransportMessageHeaders {
      * @param timestampInMs the timestamp in milliseconds
      * @param messageSequence the message sequence (optional)
      * @param fixtureId the fixture ID (optional)
+     * @param marketId the market ID (optional)
      * @param sportId the sport ID (optional)
      */
     private TransportMessageHeaders(String messageGuid, String messageType, String timestampInMs, 
-                                   String messageSequence, String fixtureId, String sportId) {
+                                   String messageSequence, String fixtureId, String marketId, String sportId) {
         this.messageGuid = messageGuid;
         this.messageType = messageType;
         this.timestampInMs = timestampInMs;
         this.messageSequence = messageSequence;
         this.fixtureId = fixtureId;
+        this.marketId = marketId;
         this.sportId = sportId;
     }
 
@@ -81,6 +85,15 @@ public class TransportMessageHeaders {
     }
 
     /**
+     * Gets the market ID.
+     *
+     * @return the market ID
+     */
+    public String getMarketId() {
+        return marketId;
+    }
+
+    /**
      * Gets the sport ID.
      *
      * @return the sport ID
@@ -115,9 +128,10 @@ public class TransportMessageHeaders {
         String timestampInMs = getRequiredProperty(properties, TIMESTAMP_IN_MS_KEY, true);
         String messageSequence = getRequiredProperty(properties, MESSAGE_SEQUENCE_KEY, false);
         String fixtureId = getRequiredProperty(properties, FIXTURE_ID_KEY, false);
+        String marketId = getRequiredProperty(properties, MARKET_ID_KEY, false);
         String sportId = getRequiredProperty(properties, SPORT_ID_KEY, false);
 
-        return new TransportMessageHeaders(messageGuid, messageType, timestampInMs, messageSequence, fixtureId, sportId);
+        return new TransportMessageHeaders(messageGuid, messageType, timestampInMs, messageSequence, fixtureId, marketId, sportId);
     }
 
     /**
@@ -146,6 +160,10 @@ public class TransportMessageHeaders {
         
         if (!isNullOrEmpty(fixtureId)) {
             headerMap.put(FIXTURE_ID_KEY, fixtureId);
+        }
+
+        if (!isNullOrEmpty(marketId)) {
+            headerMap.put(MARKET_ID_KEY, marketId);
         }
         
         if (!isNullOrEmpty(sportId)) {

--- a/sdk/trade360-java-sdk/src/test/java/eu/lsports/trade360_java_sdk/common/models/TransportMessageHeadersTest.java
+++ b/sdk/trade360-java-sdk/src/test/java/eu/lsports/trade360_java_sdk/common/models/TransportMessageHeadersTest.java
@@ -47,6 +47,7 @@ class TransportMessageHeadersTest {
             String originalTimestampInMs = headers.getTimestampInMs();
             String originalMessageSequence = headers.getMessageSequence();
             String originalFixtureId = headers.getFixtureId();
+            String originalMarketId = headers.getMarketId();
             String originalSportId = headers.getSportId();
 
             // Multiple calls should return identical values (immutability)
@@ -55,6 +56,7 @@ class TransportMessageHeadersTest {
             assertEquals(originalTimestampInMs, headers.getTimestampInMs());
             assertEquals(originalMessageSequence, headers.getMessageSequence());
             assertEquals(originalFixtureId, headers.getFixtureId());
+            assertEquals(originalMarketId, headers.getMarketId());
             assertEquals(originalSportId, headers.getSportId());
         }
 
@@ -121,6 +123,7 @@ class TransportMessageHeadersTest {
             assertEquals("1234567890", headers.getTimestampInMs());
             assertEquals("100", headers.getMessageSequence());
             assertEquals("fixture-123", headers.getFixtureId());
+            assertEquals("market-202", headers.getMarketId());
             assertEquals("sport-456", headers.getSportId());
         }
 
@@ -143,6 +146,7 @@ class TransportMessageHeadersTest {
             assertEquals("1234567890", headers.getTimestampInMs());
             assertEquals("", headers.getMessageSequence());
             assertEquals("", headers.getFixtureId());
+            assertEquals("", headers.getMarketId());
             assertEquals("", headers.getSportId());
         }
 
@@ -298,6 +302,7 @@ class TransportMessageHeadersTest {
             properties.put("timestamp_in_ms", "1234567890");
             properties.put("MessageSequence", null);
             properties.put("FixtureId", null);
+            properties.put("MarketId", null);
             properties.put("SportId", null);
 
             // When
@@ -307,6 +312,7 @@ class TransportMessageHeadersTest {
             assertNotNull(headers);
             assertEquals("", headers.getMessageSequence());
             assertEquals("", headers.getFixtureId());
+            assertEquals("", headers.getMarketId());
             assertEquals("", headers.getSportId());
         }
     }
@@ -373,6 +379,19 @@ class TransportMessageHeadersTest {
         }
 
         @Test
+        @DisplayName("Should return correct market ID")
+        void shouldReturnCorrectMarketId() {
+            // Given
+            TransportMessageHeaders headers = createHeadersInstance();
+
+            // When
+            String marketId = headers.getMarketId();
+
+            // Then
+            assertEquals("market-202", marketId);
+        }
+
+        @Test
         @DisplayName("Should return correct sport ID")
         void shouldReturnCorrectSportId() {
             // Given
@@ -415,12 +434,13 @@ class TransportMessageHeadersTest {
 
             // Then
             assertNotNull(resultMap);
-            assertEquals(6, resultMap.size());
+            assertEquals(7, resultMap.size());
             assertEquals("test-guid", resultMap.get("MessageGuid"));
             assertEquals("TestMessage", resultMap.get("MessageType"));
             assertEquals("1234567890", resultMap.get("timestamp_in_ms"));
             assertEquals("100", resultMap.get("MessageSequence"));
             assertEquals("fixture-123", resultMap.get("FixtureId"));
+            assertEquals("market-202", resultMap.get("MarketId"));
             assertEquals("sport-456", resultMap.get("SportId"));
         }
 
@@ -671,6 +691,7 @@ class TransportMessageHeadersTest {
             assertEquals(headers1.getTimestampInMs(), headers2.getTimestampInMs());
             assertEquals(headers1.getMessageSequence(), headers2.getMessageSequence());
             assertEquals(headers1.getFixtureId(), headers2.getFixtureId());
+            assertEquals(headers1.getMarketId(), headers2.getMarketId());
             assertEquals(headers1.getSportId(), headers2.getSportId());
             
             // Maps should also be equal
@@ -690,6 +711,7 @@ class TransportMessageHeadersTest {
         properties.put("timestamp_in_ms", "1234567890");
         properties.put("MessageSequence", "100");
         properties.put("FixtureId", "fixture-123");
+        properties.put("MarketId", "market-202");
         properties.put("SportId", "sport-456");
         return properties;
     }


### PR DESCRIPTION
# User description
## Summary
- Add optional `MarketId` customer message header to `TransportMessageHeaders`, including `getMarketId()` and `getAsMap()` support
- Bump project/module versions to **2.10.1** and update changelog

Linear: https://linear.app/lsports-ltd/issue/TRGN-3848/add-marketid-to-sdks-part-of-customer-message-headers

## Test plan
- [x] `mvn test -Dtest=TransportMessageHeadersTest` passing
- [ ] CI green on PR

Made with [Cursor](https://cursor.com)

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Add optional MarketId transport header to <code>TransportMessageHeaders</code> so SDK consumers can continue to include the additional identifier across header serialization and parsing routines. Bump the SDK, samples, and parent module versions to 2.10.1 and record the release in the changelog for publishing.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/lsportsltd/trade360-java-sdk/131?tool=ast&topic=MarketId+headers>MarketId headers</a>
        </td><td>Add optional MarketId support to <code>TransportMessageHeaders</code> by including the key constant, constructor field, getter, map serialization, and matching unit test coverage so the new header mirrors existing fixture/sport behavior.<details><summary>Modified files (2)</summary><ul><li>sdk/trade360-java-sdk/src/main/java/eu/lsports/trade360_java_sdk/common/models/TransportMessageHeaders.java</li>
<li>sdk/trade360-java-sdk/src/test/java/eu/lsports/trade360_java_sdk/common/models/TransportMessageHeadersTest.java</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>shir.b@lsports.eu</td><td>TRGN-3848: Add MarketI...</td><td>June 14, 2026</td></tr>
<tr><td>Phil1903</td><td>Added SportId to rmq h...</td><td>January 18, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/lsportsltd/trade360-java-sdk/131?tool=ast&topic=Release+bump>Release bump</a>
        </td><td>Align the parent, SDK, and sample POM versions plus the changelog entry with the new 2.10.1 release that ships the MarketId header support.<details><summary>Modified files (4)</summary><ul><li>CHANGELOG.md</li>
<li>pom.xml</li>
<li>samples/trade360-samples/pom.xml</li>
<li>sdk/trade360-java-sdk/pom.xml</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>shir.b@lsports.eu</td><td>TRGN-3848: Add MarketI...</td><td>June 14, 2026</td></tr>
<tr><td>PavelTemno</td><td>fix versioning</td><td>January 27, 2026</td></tr></table></details></td></tr></table>
<sub><a href="https://baz.co/changes/lsportsltd/trade360-java-sdk/131?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>