### PR TITLE
PRD-1516: Java SDK Market Status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [Release Version 2.11.1] - 2026-07-01
+
+### Added
+
+- **`MarketStatus`** enum (`NOT_SET`, `OPEN`, `SUSPENDED`, `SETTLED`) for authoritative market-level status (PRD-1516).
+- **`Market.status`**: maps JSON `Status` on market payloads (1=Open, 2=Suspended, 3=Settled).
+- **`FixtureMarketElement.status`** and **`OutrightMarketElement.status`** for snapshot API market responses.
+
+### Changed
+
+- Bumped project/module versions from `2.11.0` to `2.11.1` for a new publishable release.
+
 ## [Release Version 2.11.0] - 2026-06-14
 
 ### Added

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>eu.lsports</groupId>
 	<artifactId>trade360-java</artifactId>
-	<version>2.11.0</version>
+	<version>2.11.1</version>
 	<packaging>pom</packaging>
 
 	<modules>

--- a/samples/trade360-samples/pom.xml
+++ b/samples/trade360-samples/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>eu.lsports</groupId>
     <artifactId>trade360-samples</artifactId>
-    <version>2.11.0</version>
+    <version>2.11.1</version>
     <name>trade360-samples</name>
     <description>LSports trade360-samples java sdk</description>
     <properties>
@@ -20,7 +20,7 @@
         <dependency>
             <groupId>eu.lsports</groupId>
             <artifactId>trade360-java-sdk</artifactId>
-            <version>2.11.0</version>
+            <version>2.11.1</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/sdk/trade360-java-sdk/pom.xml
+++ b/sdk/trade360-java-sdk/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>eu.lsports</groupId>
     <artifactId>trade360-java-sdk</artifactId>
-    <version>2.11.0</version>
+    <version>2.11.1</version>
     <name>trade360-java-sdk</name>
     <description>LSports trade360 java sdk</description>
     <parent>

--- a/sdk/trade360-java-sdk/src/main/java/eu/lsports/trade360_java_sdk/common/entities/enums/MarketStatus.java
+++ b/sdk/trade360-java-sdk/src/main/java/eu/lsports/trade360_java_sdk/common/entities/enums/MarketStatus.java
@@ -1,0 +1,24 @@
+package eu.lsports.trade360_java_sdk.common.entities.enums;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+
+/**
+ * Trade360 market-level status (distinct from bet {@link BetStatus}).
+ */
+public enum MarketStatus {
+    NOT_SET(0),
+    OPEN(1),
+    SUSPENDED(2),
+    SETTLED(3);
+
+    private final int value;
+
+    MarketStatus(int value) {
+        this.value = value;
+    }
+
+    @JsonValue
+    public int getValue() {
+        return value;
+    }
+}

--- a/sdk/trade360-java-sdk/src/main/java/eu/lsports/trade360_java_sdk/common/entities/markets/Market.java
+++ b/sdk/trade360-java-sdk/src/main/java/eu/lsports/trade360_java_sdk/common/entities/markets/Market.java
@@ -1,5 +1,6 @@
 package eu.lsports.trade360_java_sdk.common.entities.markets;
 
+import eu.lsports.trade360_java_sdk.common.entities.enums.MarketStatus;
 import jakarta.annotation.Nullable;
 
 /**
@@ -35,4 +36,9 @@ public class Market {
      * This can be {@code null} if not set.
      */
     @Nullable public String mainLine;
+
+    /**
+     * Authoritative market status after TRADE calculation: 1=Open, 2=Suspended, 3=Settled.
+     */
+    @Nullable public MarketStatus status;
 }

--- a/sdk/trade360-java-sdk/src/main/java/eu/lsports/trade360_java_sdk/snapshot_api/entities/responses/FixtureMarketElement.java
+++ b/sdk/trade360-java-sdk/src/main/java/eu/lsports/trade360_java_sdk/snapshot_api/entities/responses/FixtureMarketElement.java
@@ -1,5 +1,6 @@
 package eu.lsports.trade360_java_sdk.snapshot_api.entities.responses;
 
+import eu.lsports.trade360_java_sdk.common.entities.enums.MarketStatus;
 import eu.lsports.trade360_java_sdk.common.entities.markets.Bet;
 
 import jakarta.annotation.Nullable;
@@ -13,6 +14,9 @@ public class FixtureMarketElement {
 
     /** The name or description of the market. */
     public String name;
+
+    /** Trade360 market status: 1=Open, 2=Suspended, 3=Settled. */
+    @Nullable public MarketStatus status;
 
     /** The collection of bets associated with this market. */
     @Nullable public Iterable<Bet> bets;

--- a/sdk/trade360-java-sdk/src/main/java/eu/lsports/trade360_java_sdk/snapshot_api/entities/responses/OutrightMarketElement.java
+++ b/sdk/trade360-java-sdk/src/main/java/eu/lsports/trade360_java_sdk/snapshot_api/entities/responses/OutrightMarketElement.java
@@ -1,5 +1,6 @@
 package eu.lsports.trade360_java_sdk.snapshot_api.entities.responses;
 
+import eu.lsports.trade360_java_sdk.common.entities.enums.MarketStatus;
 import eu.lsports.trade360_java_sdk.common.entities.markets.Bet;
 import eu.lsports.trade360_java_sdk.common.entities.markets.ProviderMarket;
 import jakarta.annotation.Nullable;
@@ -18,6 +19,9 @@ public final class OutrightMarketElement {
      * Can be {@code null}.
      */
     @Nullable public String name;
+
+    /** Trade360 market status: 1=Open, 2=Suspended, 3=Settled. */
+    @Nullable public MarketStatus status;
 
     /**
      * The collection of bets associated with the outright market element.

--- a/sdk/trade360-java-sdk/src/test/java/eu/lsports/trade360_java_sdk/common/entities/enums/MarketStatusEnumTest.java
+++ b/sdk/trade360-java-sdk/src/test/java/eu/lsports/trade360_java_sdk/common/entities/enums/MarketStatusEnumTest.java
@@ -1,0 +1,40 @@
+package eu.lsports.trade360_java_sdk.common.entities.enums;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class MarketStatusEnumTest {
+
+    @Test
+    void testEnumValues() {
+        MarketStatus[] values = MarketStatus.values();
+        assertNotNull(values);
+        assertEquals(4, values.length);
+    }
+
+    @Test
+    void testValueOf() {
+        for (MarketStatus status : MarketStatus.values()) {
+            assertEquals(status, MarketStatus.valueOf(status.name()));
+        }
+    }
+
+    @Test
+    void testNumericValues() {
+        assertEquals(0, MarketStatus.NOT_SET.getValue());
+        assertEquals(1, MarketStatus.OPEN.getValue());
+        assertEquals(2, MarketStatus.SUSPENDED.getValue());
+        assertEquals(3, MarketStatus.SETTLED.getValue());
+    }
+
+    @Test
+    void testEnumConsistency() {
+        MarketStatus[] values1 = MarketStatus.values();
+        MarketStatus[] values2 = MarketStatus.values();
+        assertEquals(values1.length, values2.length);
+        assertTrue(values1.length > 0);
+    }
+}

--- a/sdk/trade360-java-sdk/src/test/java/eu/lsports/trade360_java_sdk/common/entities/markets/MarketTest.java
+++ b/sdk/trade360-java-sdk/src/test/java/eu/lsports/trade360_java_sdk/common/entities/markets/MarketTest.java
@@ -1,17 +1,25 @@
 package eu.lsports.trade360_java_sdk.common.entities.markets;
 
-import org.junit.jupiter.api.Test;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import eu.lsports.trade360_java_sdk.common.entities.enums.MarketStatus;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import java.util.List;
 import java.util.ArrayList;
 import static org.junit.jupiter.api.Assertions.*;
 
 class MarketTest {
     private Market market;
+    private ObjectMapper objectMapper;
 
     @BeforeEach
     void setUp() {
         market = new Market();
+        objectMapper = new ObjectMapper()
+                .setPropertyNamingStrategy(PropertyNamingStrategies.UPPER_CAMEL_CASE)
+                .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
     }
 
     @Test
@@ -22,6 +30,7 @@ class MarketTest {
         assertNull(market.bets);
         assertNull(market.providerMarkets);
         assertNull(market.mainLine);
+        assertNull(market.status);
     }
 
     @Test
@@ -128,17 +137,31 @@ class MarketTest {
         assertNull(market.bets);
         assertNull(market.providerMarkets);
         assertNull(market.mainLine);
+        assertNull(market.status);
 
         market.id = 1;
         market.name = "MarketName";
         market.bets = null;
         market.providerMarkets = null;
         market.mainLine = "MainLine";
+        market.status = MarketStatus.SUSPENDED;
 
         assertEquals(1, market.id);
         assertEquals("MarketName", market.name);
         assertNull(market.bets);
         assertNull(market.providerMarkets);
         assertEquals("MainLine", market.mainLine);
+        assertEquals(MarketStatus.SUSPENDED, market.status);
+    }
+
+    @Test
+    void testDeserializeMarketStatusFromJson() throws Exception {
+        Market parsed = objectMapper.readValue(
+                "{\"Id\":52,\"Name\":\"1X2\",\"Status\":2,\"Bets\":[]}",
+                Market.class);
+
+        assertEquals(52, parsed.id);
+        assertEquals("1X2", parsed.name);
+        assertEquals(MarketStatus.SUSPENDED, parsed.status);
     }
 }   


### PR DESCRIPTION
# User description
## Summary
- Add authoritative customer-facing `Status` on Trade360 market objects (1=Open, 2=Suspended, 3=Settled), computed from the full calculated bet set after TRADE rules — never DI passthrough.
- Includes unit tests for rollup logic, status-only delta distribution, and wire/SDK mapping where applicable.

JIRA: https://lsports-data.atlassian.net/browse/PRD-1516

## Deploy order (pipeline)
Refiner → Calculator → Distributors → Logger/Snapshot → SDKs

## Test plan
- [x] Unit tests added/updated for Market Status behavior
- [ ] QA validation (TRGN-3952)

Made with [Cursor](https://cursor.com)

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Add <code>MarketStatus</code> and map it onto <code>Market</code>, <code>FixtureMarketElement</code>, and <code>OutrightMarketElement</code> so the SDK surfaces the TRADE-computed market-level status instead of raw DI passthrough. Update the SDK and sample versions to <code>2.11.1</code> and document the new release that ships the status behavior.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/lsportsltd/trade360-java-sdk/133?tool=ast&topic=Status+Tests>Status Tests</a>
        </td><td>Exercise the new <code>MarketStatus</code> enum and market deserialization to prove the status values serialize, deserialize, and stay stable.<details><summary>Modified files (2)</summary><ul><li>sdk/trade360-java-sdk/src/test/java/eu/lsports/trade360_java_sdk/common/entities/enums/MarketStatusEnumTest.java</li>
<li>sdk/trade360-java-sdk/src/test/java/eu/lsports/trade360_java_sdk/common/entities/markets/MarketTest.java</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>ortal@lsports.eu</td><td>Add MarketStatus enum ...</td><td>July 02, 2026</td></tr>
<tr><td>shir.b@lsports.eu</td><td>adding inplay outright...</td><td>November 19, 2025</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/lsportsltd/trade360-java-sdk/133?tool=ast&topic=Market+Status+Flow>Market Status Flow</a>
        </td><td>Add <code>MarketStatus</code> mapping across <code>Market</code>, snapshot market elements, and the new enum so consumers consistently see the TRADE-authoritative market-level state.<details><summary>Modified files (8)</summary><ul><li>CHANGELOG.md</li>
<li>pom.xml</li>
<li>samples/trade360-samples/pom.xml</li>
<li>sdk/trade360-java-sdk/pom.xml</li>
<li>sdk/trade360-java-sdk/src/main/java/eu/lsports/trade360_java_sdk/common/entities/enums/MarketStatus.java</li>
<li>sdk/trade360-java-sdk/src/main/java/eu/lsports/trade360_java_sdk/common/entities/markets/Market.java</li>
<li>sdk/trade360-java-sdk/src/main/java/eu/lsports/trade360_java_sdk/snapshot_api/entities/responses/FixtureMarketElement.java</li>
<li>sdk/trade360-java-sdk/src/main/java/eu/lsports/trade360_java_sdk/snapshot_api/entities/responses/OutrightMarketElement.java</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>ortal@lsports.eu</td><td>Add MarketStatus enum ...</td><td>July 02, 2026</td></tr>
<tr><td>shir.b@lsports.eu</td><td>Align Java SSL with .N...</td><td>June 14, 2026</td></tr></table></details></td></tr></table>
<sub><a href="https://baz.co/changes/lsportsltd/trade360-java-sdk/133?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>